### PR TITLE
Fix locale routing and calculators link

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  i18n: {
-    locales: ['en', 'es', 'it', 'fr'],
-    defaultLocale: 'en'
-  },
   experimental: {
     serverActions: true,   // 👈 add this line
   },

--- a/src/app/[locale]/calculator/[slug]/page.tsx
+++ b/src/app/[locale]/calculator/[slug]/page.tsx
@@ -1,0 +1,2 @@
+export { dynamicParams, generateStaticParams } from '../../../calculator/[slug]/page'
+export { default } from '../../../calculator/[slug]/page'

--- a/src/app/[locale]/calculators/page.tsx
+++ b/src/app/[locale]/calculators/page.tsx
@@ -1,0 +1,2 @@
+export { metadata } from '../../calculators/page'
+export { default } from '../../calculators/page'

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,18 +1,25 @@
 import Link from 'next/link';
- 
+import { usePathname } from 'next/navigation';
+import { locales, defaultLocale } from '@/i18n/config';
+
 export default function NotFound() {
- return (
- <div className="min-h-screen bg-gray-50 flex items-center justify-center">
- <div className="text-center">
+  const pathname = usePathname();
+  const localeMatch = pathname?.match(/^\/(\w{2})(\/|$)/);
+  const locale = localeMatch && locales.includes(localeMatch[1] as any)
+    ? localeMatch[1]
+    : defaultLocale;
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="text-center">
  <h1 className="text-6xl font-bold text-gray-900 mb-4">404</h1>
  <h2 className="text-2xl font-semibold text-gray-700 mb-4">Page Not Found</h2>
  <p className="text-gray-600 mb-8">
  The page you&apos;re looking for doesn&apos;t exist.
  </p>
- <Link 
- href="/calculators"
- className="bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition-colors"
- >
+        <Link
+          href={`/${locale}/calculators`}
+          className="bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition-colors"
+        >
  Browse Calculators
  </Link>
  </div>


### PR DESCRIPTION
### **User description**
## Summary
- remove built‑in i18n config so `[locale]` routes work
- adjust not found page to link to the correct locale calculators page
- expose calculators and calculator slug pages under each locale

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68790a2398c48323a45b545b62ffcaa1


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Remove built-in i18n config to enable `[locale]` routes

- Add locale-aware routing for calculator pages

- Fix 404 page to link to correct locale calculators

- Expose calculators under each locale path


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Remove i18n config"] --> B["Enable [locale] routes"]
  B --> C["Add locale calculator pages"]
  C --> D["Fix 404 locale detection"]
  D --> E["Correct calculators linking"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>next.config.js</strong><dd><code>Remove built-in i18n configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

next.config.js

<ul><li>Remove built-in i18n configuration object<br> <li> Keep experimental serverActions setting intact</ul>


</details>


  </td>
  <td><a href="https://github.com/robertmain53/Socalsolver.com.nj.bastard/pull/3/files#diff-882b2c04b01b2e8b2cdcf1817c30ea503a8005f1c0d54cfff37053b6801fea85">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Add locale calculator slug page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/[locale]/calculator/[slug]/page.tsx

<ul><li>Create new locale-specific calculator slug page<br> <li> Re-export functions from base calculator page</ul>


</details>


  </td>
  <td><a href="https://github.com/robertmain53/Socalsolver.com.nj.bastard/pull/3/files#diff-3ddb43e4a2853931d0f234869d657ab34031b579af5c9b4f94e687166a277394">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Add locale calculators page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/[locale]/calculators/page.tsx

<ul><li>Create new locale-specific calculators page<br> <li> Re-export metadata and component from base page</ul>


</details>


  </td>
  <td><a href="https://github.com/robertmain53/Socalsolver.com.nj.bastard/pull/3/files#diff-0577e65abb9c7a3987fa80ab1f400f5a3f20eb41e7f5ab5156cabf38c126b98f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>not-found.tsx</strong><dd><code>Add locale-aware 404 page routing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/not-found.tsx

<ul><li>Add locale detection from pathname<br> <li> Import i18n configuration and usePathname hook<br> <li> Update calculators link to include detected locale</ul>


</details>


  </td>
  <td><a href="https://github.com/robertmain53/Socalsolver.com.nj.bastard/pull/3/files#diff-f656f59519a290bb5f099f48ce59a37b32c20b0276f0e83e884051f0be43db43">+15/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

